### PR TITLE
Added logic to check for additional properties

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "args": ["-i", "beta.yaml", "-p", "/notification-templates", "--skip-sorters", "--skip-filters"],
+            "args": ["-i", "v3.yaml", "--skip-sorters", "--skip-filters"],
             //"args": ["-i", "beta.yaml"],
             "program": "${workspaceFolder}/validator.js"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "args": ["-i", "v3.yaml", "-p", "/sources", "--skip-sorters", "--skip-schema"],
+            "args": ["-i", "beta.yaml", "-p", "/notification-templates", "--skip-sorters", "--skip-filters"],
             //"args": ["-i", "beta.yaml"],
             "program": "${workspaceFolder}/validator.js"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "axios": "0.26.1",
         "axios-retry": "^3.8.0",
         "dotenv": "^16.0.1",
+        "json-schema-to-zod": "^2.0.14",
         "nvm": "^0.0.4",
         "swagger-client": "3.18.4",
         "yamljs": "^0.3.0",
-        "yargs": "^17.5.1"
+        "yargs": "^17.5.1",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@babel/runtime": {
@@ -417,6 +419,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.0.14.tgz",
+      "integrity": "sha512-Pp9wg1/AcMw5KA1RA7t6ybUTIes1yX0vp8PeE48cPnddHb+ZZWbAKPaFXVf4Pif4XSbo9u9i/hIzBcS1UHK/TA==",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -751,6 +761,14 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -1043,6 +1061,11 @@
         "argparse": "^2.0.1"
       }
     },
+    "json-schema-to-zod": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.0.14.tgz",
+      "integrity": "sha512-Pp9wg1/AcMw5KA1RA7t6ybUTIes1yX0vp8PeE48cPnddHb+ZZWbAKPaFXVf4Pif4XSbo9u9i/hIzBcS1UHK/TA=="
+    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1294,6 +1317,11 @@
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/validate-master.sh
+++ b/validate-master.sh
@@ -12,8 +12,8 @@ git clone git@github.com:sailpoint/cloud-api-client-common.git
 speccy resolve --quiet cloud-api-client-common/api-specs/src/main/yaml/sailpoint-api.v3.yaml -o v3.yaml
 speccy resolve --quiet cloud-api-client-common/api-specs/src/main/yaml/sailpoint-api.beta.yaml -o beta.yaml
 
-node validator.js -i v3.yaml | tee v3-results.txt
-node validator.js -i beta.yaml | tee beta-results.txt
+node validator.js -i v3.yaml --skip-filters --skip-sorters | tee v3-results.txt
+node validator.js -i beta.yaml --skip-filters --skip-sorters | tee beta-results.txt
 
 rm -rf cloud-api-client-common
 rm v3.yaml


### PR DESCRIPTION
As mentioned in https://github.com/sailpoint-oss/api-specs/issues/54, there are instances where SailPoint's API server will return additional properties that aren't defined in the specification. This feature will find any additional properties returned by SailPoint's list endpoints.