### PR TITLE
Ignore the 'co' filter operator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "args": ["-i", "v3.yaml", "-p", "/sod-policies", "--skip-schema"],
+            "args": ["-i", "v3.yaml", "-p", "/connectors", "--skip-schema", "--skip-sorters"],
             //"args": ["-i", "beta.yaml"],
             "program": "${workspaceFolder}/validator.js"
         }

--- a/filterTests.js
+++ b/filterTests.js
@@ -55,7 +55,7 @@ function parseFilters(description) {
         const attOpSplit = line.replaceAll("*", "").split(":");
         const attribute = attOpSplit[0].trim();
         const opSplit = attOpSplit[1].trim().split(",");
-        const operators = opSplit.map(op => op.trim());
+        const operators = opSplit.map(op => op.trim()).filter(op => op !== "co"); // Don't include "co" since it's up to engineering to document it
         filters[attribute] = operators;
     })
     return filters;


### PR DESCRIPTION
We need to ignore the "co" filter operator. Only engineering should be allowed to document "co" for their endpoints.